### PR TITLE
Modernize UI with accessible color scheme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
-import {NavigationContainer} from '@react-navigation/native';
+import {NavigationContainer, DefaultTheme} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {ImageProvider} from './src/utils/ImageStore';
 import AppNavigator from './src/components/AppNavigator';
+import {colors} from './src/theme/colors';
 
 createNativeStackNavigator();
+
+const AppTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: colors.background,
+    primary: colors.primary,
+    card: colors.surface,
+    text: colors.text,
+    border: colors.muted,
+  },
+};
+
 export default function App() {
   return (
     <ImageProvider>
-      <NavigationContainer>
+      <NavigationContainer theme={AppTheme}>
         <AppNavigator />
       </NavigationContainer>
     </ImageProvider>

--- a/index.js
+++ b/index.js
@@ -12,4 +12,3 @@ AppRegistry.registerComponent(appName, () => App);
 
 // Ignore log notification by message:
 LogBox.ignoreLogs(['Warning: ...']);
-

--- a/src/components/AppNavigator.tsx
+++ b/src/components/AppNavigator.tsx
@@ -7,6 +7,7 @@ import {
 import AnimalInfoScreen from '../screens/AnimalInfoScreen';
 import CameraScreen from '../screens/CameraScreen.tsx';
 import HistoryScreen from '../screens/HistoryScreen'; // Adjust the path as necessary
+import {colors} from '../theme/colors';
 
 type RootStackParamList = {
   Camera: undefined;
@@ -45,7 +46,12 @@ export type RootNavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 const AppNavigator: React.FC = () => {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: {backgroundColor: colors.primary},
+        headerTintColor: colors.surface,
+        headerTitleStyle: {color: colors.surface},
+      }}>
       <Stack.Screen
         name="Camera"
         component={CameraScreen}

--- a/src/components/CameraButtons.tsx
+++ b/src/components/CameraButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, TouchableOpacity, StyleSheet} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
+import {colors} from '../theme/colors';
 
 interface CameraButtonsProps {
   setShowCamera: (showCamera: boolean) => void;
@@ -17,14 +18,16 @@ export default function CameraButtons({
     <View style={styles.container}>
       <TouchableOpacity
         style={styles.closeButton}
-        onPress={() => setShowCamera(true)}>
-        <Icon name="close" size={32} color="white" />
+        onPress={() => setShowCamera(true)}
+        accessibilityLabel="Retake photo">
+        <Icon name="close" size={32} color={colors.surface} />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.confirmButton}
         onPress={saveImage}
-        disabled={disableButton}>
-        <Icon name="check" size={32} color="white" />
+        disabled={disableButton}
+        accessibilityLabel="Save photo">
+        <Icon name="check" size={32} color={colors.surface} />
       </TouchableOpacity>
     </View>
   );
@@ -43,7 +46,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   closeButton: {
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: colors.secondary,
     borderRadius: 30,
     width: 60,
     height: 60,
@@ -51,7 +54,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   confirmButton: {
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: colors.primary,
     borderRadius: 30,
     width: 60,
     height: 60,

--- a/src/screens/AnimalInfoScreen.tsx
+++ b/src/screens/AnimalInfoScreen.tsx
@@ -3,6 +3,7 @@ import {ScrollView, Image, StyleSheet, View} from 'react-native';
 import {Card, Text} from 'react-native-elements';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {AnimalInfoScreenProps} from '../components/AppNavigator.tsx';
+import {colors} from '../theme/colors';
 
 interface SectionProps {
   title: string;
@@ -22,7 +23,7 @@ const AnimalInfoScreen: React.FC<AnimalInfoScreenProps> = ({route}) => {
     saveHistory(animalInfo);
   }, [animalInfo]);
 
-  const saveHistory = async (animalInfo: {
+  const saveHistory = async (info: {
     imagePath: string;
     commonName: string;
     scientificName: string;
@@ -43,7 +44,7 @@ const AnimalInfoScreen: React.FC<AnimalInfoScreenProps> = ({route}) => {
     try {
       const history = await AsyncStorage.getItem('animalHistory');
       const historyArray = history ? JSON.parse(history) : [];
-      historyArray.push(animalInfo);
+      historyArray.push(info);
       await AsyncStorage.setItem('animalHistory', JSON.stringify(historyArray));
     } catch (error) {
       console.error('Failed to save history:', error);
@@ -109,7 +110,7 @@ const formatSize = (size: Size) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F0F0F3',
+    backgroundColor: colors.background,
   },
   image: {
     width: '100%',
@@ -120,14 +121,14 @@ const styles = StyleSheet.create({
   commonName: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#2D3748',
+    color: colors.primary,
     marginBottom: 10,
     textAlign: 'center',
   },
   scientificName: {
     fontSize: 22,
     fontStyle: 'italic',
-    color: '#4A5568',
+    color: colors.secondary,
     marginBottom: 25,
     textAlign: 'center',
   },
@@ -139,17 +140,17 @@ const styles = StyleSheet.create({
   keyText: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#2D3748',
+    color: colors.text,
     minWidth: 130,
   },
   valueText: {
     fontSize: 18,
-    color: '#4A5568',
+    color: colors.muted,
     flex: 1,
     flexWrap: 'wrap',
   },
   section: {
-    backgroundColor: '#FFF',
+    backgroundColor: colors.surface,
     borderRadius: 10,
     padding: 20,
     marginBottom: 30,
@@ -165,7 +166,7 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#333',
+    color: colors.primary,
     marginBottom: 15,
   },
   sectionContainer: {
@@ -173,7 +174,7 @@ const styles = StyleSheet.create({
   },
   sectionDivider: {
     height: 1,
-    backgroundColor: '#DDDDDD',
+    backgroundColor: colors.muted,
     marginHorizontal: 20,
   },
   cardContainer: {

--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -18,7 +18,7 @@ import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProp} from '../components/AppNavigator.tsx';
 import {getImageForApi} from '../utils/utils.ts';
 import {launchImageLibrary} from 'react-native-image-picker';
-import {useFocusEffect} from '@react-navigation/native';
+import {colors} from '../theme/colors';
 
 export default function CameraScreen() {
   const {addImage} = useImages();
@@ -261,7 +261,8 @@ export default function CameraScreen() {
           <View style={styles.buttonContainer}>
             <TouchableOpacity
               style={styles.searchButton}
-              onPress={() => capturePhoto()}>
+              onPress={() => capturePhoto()}
+              accessibilityLabel="Capture photo">
               <Image
                 source={require('./search-icon.png')}
                 style={styles.searchIcon}
@@ -269,7 +270,8 @@ export default function CameraScreen() {
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.galleryButton}
-              onPress={handleImagePicker}>
+              onPress={handleImagePicker}
+              accessibilityLabel="Open gallery">
               {lastCapturedImage ? (
                 <Image
                   source={{
@@ -284,7 +286,8 @@ export default function CameraScreen() {
             {lastCapturedImage ? (
               <TouchableOpacity
                 style={styles.historyButton}
-                onPress={handleNavigateToHistory}>
+                onPress={handleNavigateToHistory}
+                accessibilityLabel="Open history">
                 <Text style={styles.historyButtonText}>Istorija</Text>
               </TouchableOpacity>
             ) : null}
@@ -311,7 +314,7 @@ export default function CameraScreen() {
       )}
       {isLoading ? (
         <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" color="#00ff00" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : null}
     </View>
@@ -323,9 +326,10 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: colors.background,
   },
   button: {
-    backgroundColor: 'gray',
+    backgroundColor: colors.primary,
   },
   buttonContainer: {
     backgroundColor: 'rgba(0,0,0,0.4)',
@@ -340,10 +344,10 @@ const styles = StyleSheet.create({
     height: 80,
     width: 80,
     borderRadius: 40,
-    backgroundColor: '#B2BEB5',
+    backgroundColor: colors.accent,
     alignSelf: 'center',
     borderWidth: 4,
-    borderColor: 'white',
+    borderColor: colors.surface,
   },
   image: {
     width: '100%',
@@ -361,14 +365,14 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   navigationButton: {
-    backgroundColor: 'blue',
+    backgroundColor: colors.secondary,
     paddingVertical: 10,
     paddingHorizontal: 20,
     borderRadius: 5,
     marginTop: 20,
   },
   navigationButtonText: {
-    color: 'white',
+    color: colors.surface,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -376,7 +380,7 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: 'white',
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -391,7 +395,7 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: 'white',
+    backgroundColor: colors.accent,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -403,6 +407,7 @@ const styles = StyleSheet.create({
   galleryButtonText: {
     fontSize: 12,
     fontWeight: 'bold',
+    color: colors.surface,
   },
   historyButton: {
     position: 'absolute',
@@ -411,12 +416,13 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: 'white',
+    backgroundColor: colors.secondary,
     justifyContent: 'center',
     alignItems: 'center',
   },
   historyButtonText: {
     fontSize: 12,
     fontWeight: 'bold',
+    color: colors.surface,
   },
 });

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -7,6 +7,7 @@ import {
   View,
   Text,
 } from 'react-native';
+import {colors} from '../theme/colors';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProp} from '../components/AppNavigator.tsx';
@@ -51,7 +52,8 @@ const HistoryScreen = () => {
         <TouchableOpacity
           key={index}
           style={styles.cardContainer}
-          onPress={() => handleCardPress(item)}>
+          onPress={() => handleCardPress(item)}
+          accessibilityLabel={`View details for ${item.commonName}`}>
           <View style={styles.card}>
             <Image source={{uri: item.imagePath}} style={styles.image} />
             <View style={styles.textContainer}>
@@ -68,7 +70,7 @@ const HistoryScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F0F0F3',
+    backgroundColor: colors.background,
   },
   cardContainer: {
     marginHorizontal: 20,
@@ -82,7 +84,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 3.84,
     elevation: 5,
-    backgroundColor: '#FFF',
+    backgroundColor: colors.surface,
   },
   card: {
     borderRadius: 10,
@@ -99,14 +101,14 @@ const styles = StyleSheet.create({
   commonName: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#2D3748',
+    color: colors.primary,
     marginBottom: 5,
     textAlign: 'center',
   },
   scientificName: {
     fontSize: 18,
     fontStyle: 'italic',
-    color: '#4A5568',
+    color: colors.secondary,
     textAlign: 'center',
   },
 });

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,10 @@
+export const colors = {
+  primary: '#4F46E5',
+  secondary: '#10B981',
+  background: '#F9FAFB',
+  surface: '#FFFFFF',
+  text: '#1F2937',
+  muted: '#6B7280',
+  accent: '#F59E0B',
+};
+export default colors;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,9 +1,8 @@
 import RNFS from 'react-native-fs';
-import { parseJsonString } from '../services/helper.ts';
-import * as dotenv from 'dotenv'
+import {parseJsonString} from '../services/helper.ts';
+import * as dotenv from 'dotenv';
 
-dotenv.config()
-
+dotenv.config();
 
 const SYSTEM_PROMPT =
   'You are an AI assistant that specializes in identifying animals and providing detailed information about them in a structured JSON format. When a user describes an animal or provides an image of an animal, you should follow these steps: Analyze the input (description or image) to identify the animal species. If you are unable to identify any animals in the input, generate a JSON object with an error message: {"error": "No animals found in the provided description or image."} If you are able to identify an animal but with low confidence, ask for more information or a clearer image. Once you have confidently identified an animal, generate a JSON object containing the following information: commonName: The common name of the animal, scientificName: The scientific name of the animal (genus and species), classification: A nested object containing the taxonomic classification (kingdom, phylum, class, order, family, genus, species), characteristics: A nested object containing information about the animal\'s habitat, diet, lifespan, size (length, height, weight), color, and distinctive features, behaviors: A nested object containing information about the animal\'s social structure, activity cycle, and predatory behaviors (if applicable), conservationStatus: The conservation status of the animal (e.g., Least Concern, Vulnerable, Endangered), geographicalDistribution: A nested object containing the continent(s) and regions where the animal is found, observations: A nested object containing information about threats to the animal and conservation efforts (if applicable). Format the JSON object with proper indentation and syntax highlighting for readability. Return the formatted JSON object as your response to the user.';
@@ -24,7 +23,7 @@ export async function getImageForApi(imagePath: string) {
           {
             role: 'user',
             content: [
-              { type: 'text', text: SYSTEM_PROMPT },
+              {type: 'text', text: SYSTEM_PROMPT},
               {
                 type: 'image_url',
                 image_url: {


### PR DESCRIPTION
## Summary
- add centralized color palette and apply across app
- modernize navigation and screen styles with accessible colors
- include accessibility labels for camera controls

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1f781404c8333a9295eef4728743a